### PR TITLE
backport fetch group offsets

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -609,6 +609,14 @@ module Kafka
       @cluster.describe_group(group_id)
     end
 
+    # Fetch all committed offsets for a consumer group
+    #
+    # @param group_id [String] the id of the consumer group
+    # @return [Hash<String, Hash<Integer, Kafka::Protocol::OffsetFetchResponse::PartitionOffsetInfo>>]
+    def fetch_group_offsets(group_id)
+      @cluster.fetch_group_offsets(group_id)
+    end
+
     # Create partitions for a topic.
     #
     # @param name [String] the name of the topic.

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -252,6 +252,20 @@ module Kafka
       group
     end
 
+    def fetch_group_offsets(group_id)
+      topics = get_group_coordinator(group_id: group_id)
+        .fetch_offsets(group_id: group_id, topics: nil)
+        .topics
+
+      topics.each do |_, partitions|
+        partitions.each do |_, response|
+          Protocol.handle_error(response.error_code)
+        end
+      end
+
+      topics
+    end
+
     def create_partitions_for(name, num_partitions:, timeout:)
       options = {
         topics: [[name, num_partitions, nil]],

--- a/lib/kafka/protocol/offset_fetch_request.rb
+++ b/lib/kafka/protocol/offset_fetch_request.rb
@@ -13,7 +13,7 @@ module Kafka
       end
 
       def api_version
-        1
+        @topics.nil? ? 2 : 1
       end
 
       def response_class


### PR DESCRIPTION
This backports the fetch_group_offsets method made available in ruby-kafka v1.0.0 from this commit https://github.com/zendesk/ruby-kafka/commit/3de78669735111a7e164ce2e22f79824f33d70e7

